### PR TITLE
Ci/readthedocs preview

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: "readthedocs-preview"
+          project-slug: "static_queue"

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,20 @@
+name: readthedocs/actions
+on:
+  pull_request_target:
+    types:
+      - opened
+    # Execute this action only on PRs that touch
+    # documentation files.
+    # paths:
+    #   - "docs/**"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "readthedocs-preview"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the generation of documentation previews using Read the Docs when a pull request is opened. 

New GitHub Actions workflow:

* [`.github/workflows/documentation-links.yml`](diffhunk://#diff-db385bef49fd7ab6efc0338151a618fc693503d724ed03c2555c5ea62a1ef474R1-R20): Added a workflow that triggers on pull requests targeting documentation files and generates a preview using Read the Docs.