### PR TITLE
Fix project slug in GitHub Actions workflow and bump version to 0.3.1

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: "static_queue"
+          project-slug: "static-queue"

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'static_queue',
   'c',
-  version: '0.3.0',
+  version: '0.3.1',
   meson_version: '>=1.1.0',
   default_options: ['buildtype=release', 'warning_level=3'],
   license: 'MIT license',


### PR DESCRIPTION


<!-- readthedocs-preview static_queue start -->
----
📚 Documentation preview 📚: https://static_queue--6.org.readthedocs.build/en/6/

<!-- readthedocs-preview static_queue end -->